### PR TITLE
Add directory navigation to custom file explorer

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -11,12 +11,15 @@ pub enum Message {
     OpenDialog,
     CloseDialog,
     SelectPath(PathBuf),
+    EnterDirectory,
+    GoBackFromDirectory,
 }
 
 pub struct ExplorerState {
     pub path: PathBuf,
     pub items: Vec<String>,
     pub list_state: ListState,
+    pub history: Vec<usize>,
 }
 
 pub struct AppState {
@@ -41,19 +44,43 @@ impl AppState {
         match msg {
             Message::OpenDialog => {
                 if let Some(path) = home::home_dir() {
-                    let items = directory_manager::list_directory_contents(path.clone());
+                    let items = directory_manager::list_directory_contents(&path);
                     let mut list_state = ListState::default();
                     list_state.select(Some(0));
                     self.explorer = Some(ExplorerState {
                         path,
                         items,
                         list_state,
+                        history: Vec::new(),
                     });
+                }
+            }
+            Message::EnterDirectory => {
+                if let Some(explorer) = &mut self.explorer {
+                    let index = explorer.list_state.selected().unwrap_or(0);
+                    let directory_name = &explorer.items[index];
+                    let new_path = explorer.path.join(directory_name);
+                    if new_path.is_dir() {
+                        explorer.history.push(index);
+                        explorer.path = new_path;
+                        explorer.items = directory_manager::list_directory_contents(&explorer.path);
+                        explorer.list_state.select(Some(0));
+                    }
+                }
+            }
+            Message::GoBackFromDirectory => {
+                if let Some(explorer) = &mut self.explorer
+                    && let Some(parent_path) =
+                        explorer.path.parent().map(|parent| parent.to_path_buf())
+                {
+                    explorer.path = parent_path;
+                    explorer.items = directory_manager::list_directory_contents(&explorer.path);
+                    explorer.list_state.select(explorer.history.pop());
                 }
             }
             Message::CloseDialog => self.explorer = None,
             Message::SelectPath(path) => {
-                self.game_items = directory_manager::list_directory_contents(path);
+                self.game_items = directory_manager::list_directory_contents(&path);
                 self.explorer = None;
             }
             Message::MoveUp => self.move_up(),

--- a/src/directory_manager.rs
+++ b/src/directory_manager.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
 
 pub fn find_steam_root() -> Option<PathBuf> {
@@ -32,7 +33,7 @@ pub fn list_steam_games(steam_root: PathBuf) -> Vec<String> {
     }
 }
 
-pub fn list_directory_contents(dir: PathBuf) -> Vec<String> {
+pub fn list_directory_contents(dir: &Path) -> Vec<String> {
     match fs::read_dir(dir) {
         Ok(entries) => entries
             .filter_map(|res| res.ok())

--- a/src/event.rs
+++ b/src/event.rs
@@ -21,6 +21,8 @@ pub fn handle_event(state: &mut AppState) -> Result<Option<Message>, Box<dyn std
                 }
                 KeyCode::Char('j') => Message::MoveDown,
                 KeyCode::Char('k') => Message::MoveUp,
+                KeyCode::Char('h') => Message::GoBackFromDirectory,
+                KeyCode::Char('l') => Message::EnterDirectory,
                 _ => return Ok(None),
             }));
         }


### PR DESCRIPTION
- Implement 'l' to enter selected directory with history stack
- Implement 'h' to go back to parent directory and restore scroll position
- Change list_directory_contents to accept &Path instead of PathBuf to avoid cloning
- Add EnterDirectory and GoBackFromDirectory message variants
- Add history: Vec<usize> field to ExplorerState to persist scroll positions